### PR TITLE
bumped joos version, fixing any bugs

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/robot/FedEx.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/robot/FedEx.java
@@ -43,7 +43,7 @@ public class FedEx extends Robot {
     }
 
     public void initTeleOp() {
-        Command driveCommand = Command.of(() -> {
+        schedule(Command.of(() -> {
             Vector2d stick = new Vector2d(
                     gamepad.p1.getInternal().left_stick_x,
                     gamepad.p1.getInternal().left_stick_y
@@ -53,8 +53,7 @@ public class FedEx extends Robot {
                     stick.getX(), 0,
                     stick.getY()
             ));
-        }).requires(drive).runUntil(false);
-        schedule(driveCommand);
+        }).requires(drive).runUntil(false));
 
         map(gamepad.p1.a::justActivated, Command.select(() -> {
             int newLevel = lift.getLevel() + 1;

--- a/build.dependencies.gradle
+++ b/build.dependencies.gradle
@@ -28,8 +28,8 @@ dependencies {
     implementation 'org.tensorflow:tensorflow-lite-task-vision:0.2.0'
     implementation 'androidx.appcompat:appcompat:1.3.1'
     implementation 'org.firstinspires.ftc:gameAssets-FreightFrenzy:1.0.0'
-    implementation 'com.github.amarcolini.joos:command:master-SNAPSHOT'
-    implementation 'com.github.amarcolini.joos:navigation:master-SNAPSHOT'
+    implementation 'com.github.amarcolini.joos:command:0.1.2-alpha'
+    implementation 'com.github.amarcolini.joos:navigation:0.1.2-alpha'
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation 'com.acmerobotics.dashboard:dashboard:0.4.3'
 }


### PR DESCRIPTION
Changed joos version to [v0.1.2-alpha](https://github.com/amarcolini/joos/releases/tag/v0.1.2-alpha).
There was an issue where commands built using `Command.of` were expected to run continuously when decorated, but they were actually instant commands, and would never do that. v0.1.2-alpha fixed this by replacing instant commands with the new `BasicCommand`, which has the expected behavior.
